### PR TITLE
correct markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ your friends assuming they connect to their pubs more often that other
 pubs.
 
 Message types for owner of pub:
- - { type: 'pub-owner-announce', pub: '@id' }
- - { type: 'pub-owner-retract', announcement: '%id' }
+ - `{ type: 'pub-owner-announce', pub: '@id' }`
+ - `{ type: 'pub-owner-retract', announcement: '%id' }`
 
 Message types for pub:
- - { type: 'pub-owner-confirm', announcement: '%id', address: "xyz.onion", features: ["tor", "incoming-guard"] }
- - { type: 'pub-owner-reject', announcement: '%id' } // to reject a confirm later on
+ - `{ type: 'pub-owner-confirm', announcement: '%id', address: "xyz.onion", features: ["tor", "incoming-guard"] }`
+ - `{ type: 'pub-owner-reject', announcement: '%id' } // to reject a confirm later on`
 
 Example:
 
+```
 ssb-server publish --type pub-owner-announce --pub @lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=.ed25519
 
 =>
@@ -47,11 +48,15 @@ ssb-server publish --type pub-owner-announce --pub @lbocEWqF2Fg6WMYLgmfYvqJlMfL7
   },
   "timestamp": 1545478575785
 }
+```
 
 On the pub use key:
 
-ssb-server publish --type pub-owner-confirm --announcement %ZSsBgNjZcM+DSwIgvL965Ci71huNJGH5YwonUKGFb2M=.sha256 --address 4fqstkswahy3n7mupr2gvvp2qcsp6juwzn3mnqvhkaixxepvxrrtfbid.onion:8008:@lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=.ed25519
-
+```
+ssb-server publish --type pub-owner-confirm \
+  --announcement %ZSsBgNjZcM+DSwIgvL965Ci71huNJGH5YwonUKGFb2M=.sha256 \
+  --address 4fqstkswahy3n7mupr2gvvp2qcsp6juwzn3mnqvhkaixxepvxrrtfbid.onion:8008:@lbocEWqF2Fg6WMYLgmfYvqJlMfL7hiqVAV6ANjHWNw8=.ed25519
+```
 
 This can be combined with the
 [ssb-incoming-guard](https://github.com/ssbc/ssb-incoming-guard)


### PR DESCRIPTION
also make the publish command take multiple lines so you don't have to scroll.